### PR TITLE
fix: update PNPM version to 10.5.2 and add onlyBuiltDependencies in pnpm-workspace.yaml

### DIFF
--- a/flyio/web/Dockerfile
+++ b/flyio/web/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ARG NODE_VERSION=22.11.0
-ARG PNPM_VERSION=10.4.1
+ARG PNPM_VERSION=10.5.2
 
 # base
 FROM node:${NODE_VERSION}-slim AS base

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
   "devDependencies": {
     "turbo": "catalog:"
   },
-  "packageManager": "pnpm@10.4.1"
+  "packageManager": "pnpm@10.5.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,3 +79,11 @@ catalog:
   vitest: 3.0.5
   zod: 3.24.1
   zodix: 0.4.4
+onlyBuiltDependencies:
+  - '@biomejs/biome'
+  - '@clerk/shared'
+  - '@prisma/engines'
+  - duckdb
+  - esbuild
+  - prisma
+  - workerd


### PR DESCRIPTION
This pull request includes updates to the `pnpm` version and modifications to the `pnpm-workspace.yaml` file. The most important changes include updating the `pnpm` version and adding specific dependencies to the `onlyBuiltDependencies` list.

Dependency updates:

* [`flyio/web/Dockerfile`](diffhunk://#diff-3c31f8016624e39251bb63efa05c336f718e44b5c88e67ee5a426384fe30fc80L4-R4): Updated `PNPM_VERSION` from `10.4.1` to `10.5.2`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16): Updated `packageManager` to use `pnpm@10.5.2`.

Workspace configuration:

* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR82-R89): Added several dependencies to the `onlyBuiltDependencies` list, including `@biomejs/biome`, `@clerk/shared`, `@prisma/engines`, `duckdb`, `esbuild`, `prisma`, and `workerd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the package manager version for enhanced performance and reliability.
	- Introduced improved organization of build-related dependencies to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->