### PR TITLE
fix: update prefetch strategy to use 'viewport' for improved performance

### DIFF
--- a/apps/web/app/routes/_public.($lang)+/_index/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/_index/route.tsx
@@ -62,7 +62,7 @@ export default function IndexPage({
           <Link
             key={area.areaId}
             to={`area/${area.areaId}`}
-            prefetch="intent"
+            prefetch="viewport"
             viewTransition
           >
             <Card className="hover:bg-secondary h-full">

--- a/apps/web/app/routes/_public.($lang)+/_layout/components/area-title.tsx
+++ b/apps/web/app/routes/_public.($lang)+/_layout/components/area-title.tsx
@@ -18,7 +18,7 @@ export const AreaTitle = ({ city, languageId, ...props }: AreaTitleProps) => {
 
   return (
     <h1 className="flex flex-wrap items-end gap-x-2 text-xl font-bold">
-      <Link to={`${language.path}`} prefetch="intent" viewTransition>
+      <Link to={`${language.path}`} prefetch="viewport" viewTransition>
         Hyperlocal {city.i18n[languageId]}
       </Link>
     </h1>

--- a/apps/web/app/routes/_public.($lang)+/area.$area.$category.$rank/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/area.$area.$category.$rank/route.tsx
@@ -88,17 +88,17 @@ export default function CategoryIndexPage({
       <Tabs value={rankingType}>
         <TabsList>
           <TabsTrigger value="rating">
-            <NavLink to={'../rating'} viewTransition>
+            <NavLink to={'../rating'} prefetch="viewport" viewTransition>
               Top Rated
             </NavLink>
           </TabsTrigger>
           <TabsTrigger value="review" asChild>
-            <NavLink to={'../review'} viewTransition>
+            <NavLink to={'../review'} prefetch="viewport" viewTransition>
               Most Popular
             </NavLink>
           </TabsTrigger>
           <TabsTrigger value="nearme" asChild>
-            <NavLink to={'../nearme'} viewTransition>
+            <NavLink to={'../nearme'} prefetch="viewport" viewTransition>
               {({ isPending }) => (
                 <span>
                   Near Me

--- a/apps/web/app/routes/_public.($lang)+/area.$area.$category.nearme/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/area.$area.$category.nearme/route.tsx
@@ -131,12 +131,12 @@ export default function CategoryIndexPage() {
       <Tabs value="nearme">
         <TabsList>
           <TabsTrigger value="rating">
-            <NavLink to={'../rating'} viewTransition>
+            <NavLink to={'../rating'} prefetch="viewport" viewTransition>
               Top Rated
             </NavLink>
           </TabsTrigger>
           <TabsTrigger value="review" asChild>
-            <NavLink to={'../review'} viewTransition>
+            <NavLink to={'../review'} prefetch="viewport" viewTransition>
               Most Popular
             </NavLink>
           </TabsTrigger>
@@ -145,7 +145,7 @@ export default function CategoryIndexPage() {
             className="border data-[state=active]:border-blue-500 data-[state=active]:text-blue-500"
             asChild
           >
-            <NavLink to={'../nearme'} viewTransition>
+            <NavLink to={'../nearme'} prefetch="viewport" viewTransition>
               Near Me
             </NavLink>
           </TabsTrigger>
@@ -178,12 +178,12 @@ export const HydrateFallback = () => {
       <Tabs value="nearme">
         <TabsList>
           <TabsTrigger value="rating">
-            <NavLink to={'../rating'} viewTransition>
+            <NavLink to={'../rating'} prefetch="viewport" viewTransition>
               Top Rated
             </NavLink>
           </TabsTrigger>
           <TabsTrigger value="review" asChild>
-            <NavLink to={'../review'} viewTransition>
+            <NavLink to={'../review'} prefetch="viewport" viewTransition>
               Most Popular
             </NavLink>
           </TabsTrigger>
@@ -192,7 +192,7 @@ export const HydrateFallback = () => {
             className="border data-[state=active]:border-blue-500 data-[state=active]:text-blue-500"
             asChild
           >
-            <NavLink to={'../nearme'} viewTransition>
+            <NavLink to={'../nearme'} prefetch="viewport" viewTransition>
               Near Me
               <LoaderIcon className="ml-2 inline h-4 w-4 animate-spin text-blue-500" />
             </NavLink>

--- a/apps/web/app/routes/_public.($lang)+/area.$area.$category/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/area.$area.$category/route.tsx
@@ -32,7 +32,11 @@ export default function AreaCategory({
 
   return (
     <Stack>
-      <Link to={`${lang.path}area/${area.areaId}`} viewTransition>
+      <Link
+        to={`${lang.path}area/${area.areaId}`}
+        prefetch="viewport"
+        viewTransition
+      >
         <div className="hover:bg-secondary flex rounded-md border p-2">
           <div className="flex-1">
             <div

--- a/apps/web/app/routes/_public.($lang)+/area.$area._index/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/area.$area._index/route.tsx
@@ -68,7 +68,12 @@ export default function AreaIndexPage({
         <h4 className="font-semibold">Places</h4>
         <div className="grid grid-cols-2 gap-2">
           {categories.map((category) => (
-            <Link to={`${category.id}/rating`} key={category.id} viewTransition>
+            <Link
+              to={`${category.id}/rating`}
+              key={category.id}
+              prefetch="viewport"
+              viewTransition
+            >
               <Card className="hover:bg-secondary">
                 <CardHeader>
                   <CardTitle

--- a/apps/web/app/routes/_public.($lang)+/place.$place/route.tsx
+++ b/apps/web/app/routes/_public.($lang)+/place.$place/route.tsx
@@ -71,6 +71,7 @@ export default function SpotDetail({
                 <BreadcrumbLink asChild>
                   <Link
                     to={`${lang.path}area/${area.areaId}`}
+                    prefetch="viewport"
                     viewTransition
                     style={{
                       viewTransitionName: `area-title-${area.areaId}`,
@@ -85,6 +86,7 @@ export default function SpotDetail({
                 <BreadcrumbLink asChild>
                   <Link
                     to={`${lang.path}area/${area?.areaId}/${category?.id}/${rank}`}
+                    prefetch="viewport"
                     viewTransition
                     style={{
                       viewTransitionName: `nav-category-${category?.id}`,
@@ -99,7 +101,7 @@ export default function SpotDetail({
 
           <div>
             <Button variant="ghost" asChild>
-              <Link to={getBackToListUrl()} viewTransition>
+              <Link to={getBackToListUrl()} prefetch="viewport" viewTransition>
                 <ChevronLeft className="mr-2 h-4 w-4" />
                 Back to List
               </Link>


### PR DESCRIPTION
This pull request includes multiple changes aimed at improving the performance of link prefetching throughout the application. The main change involves updating the `prefetch` attribute of `Link` and `NavLink` components to use "viewport" instead of "intent".

Changes to link prefetching:

* [`apps/web/app/routes/_public.($lang)+/_index/route.tsx`](diffhunk://#diff-5ae3e5e12ebf745dbcde78d77c970f019da780a81af056718b032fa95b485f00L65-R65): Updated `Link` component's `prefetch` attribute to "viewport" for better performance.
* [`apps/web/app/routes/_public.($lang)+/_layout/components/area-title.tsx`](diffhunk://#diff-0b850bafe3bb219863ed3244f22086e42ed1234b64f075cbb7f62383fd72b199L21-R21): Changed `Link` component's `prefetch` attribute to "viewport".
* [`apps/web/app/routes/_public.($lang)+/area.$area.$category.$rank/route.tsx`](diffhunk://#diff-85e0647ba3488755ac38ced7a072d1462e161a835ec9fb3c66e6e684e30fd387L91-R101): Updated multiple `NavLink` components to use "viewport" for the `prefetch` attribute.
* [`apps/web/app/routes/_public.($lang)+/area.$area.$category.nearme/route.tsx`](diffhunk://#diff-bd7a9f009898a3e3b1b63910a5109b08bb7d76f2a3df8948efccd875d5c1639bL134-R139): Modified several `NavLink` components to use "viewport" for the `prefetch` attribute. [[1]](diffhunk://#diff-bd7a9f009898a3e3b1b63910a5109b08bb7d76f2a3df8948efccd875d5c1639bL134-R139) [[2]](diffhunk://#diff-bd7a9f009898a3e3b1b63910a5109b08bb7d76f2a3df8948efccd875d5c1639bL148-R148) [[3]](diffhunk://#diff-bd7a9f009898a3e3b1b63910a5109b08bb7d76f2a3df8948efccd875d5c1639bL181-R186) [[4]](diffhunk://#diff-bd7a9f009898a3e3b1b63910a5109b08bb7d76f2a3df8948efccd875d5c1639bL195-R195)
* [`apps/web/app/routes/_public.($lang)+/area.$area.$category/route.tsx`](diffhunk://#diff-6f1b5fa76e082781609f017bba1e8dfdb40018508cdfc2d896b9f5fa82b4697aL35-R39): Updated `Link` component to use "viewport" for the `prefetch` attribute.
* [`apps/web/app/routes/_public.($lang)+/area.$area._index/route.tsx`](diffhunk://#diff-6727b653cf2cda3733dc818ae66a3e30b8b527539b1893b2a3e387d86b883611L71-R76): Changed `Link` component's `prefetch` attribute to "viewport".
* [`apps/web/app/routes/_public.($lang)+/place.$place/route.tsx`](diffhunk://#diff-3483067c1441f7fd333798071cd11160f6dfcc5132efec1e5950afb9aea20f4dR74): Updated multiple `Link` components to use "viewport" for the `prefetch` attribute. [[1]](diffhunk://#diff-3483067c1441f7fd333798071cd11160f6dfcc5132efec1e5950afb9aea20f4dR74) [[2]](diffhunk://#diff-3483067c1441f7fd333798071cd11160f6dfcc5132efec1e5950afb9aea20f4dR89) [[3]](diffhunk://#diff-3483067c1441f7fd333798071cd11160f6dfcc5132efec1e5950afb9aea20f4dL102-R104)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved link prefetching across the application: Links now load related content when they enter the viewport, enhancing page load efficiency and overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->