### PR TITLE
fix(ci): pnpmビルドエラーを修正するためにCI環境変数を設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,8 @@ jobs:
     # only build/deploy main branch on pushes
     if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    env:
+      CI: true
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION

GitHub ActionsのCI/CDパイプラインで発生していたpnpmのビルドエラーを修正します。

## 変更点

- `.github/workflows/deploy.yml` の `deploy-web` ジョブに `env: CI: true` を設定しました。

## 背景

現状のCI設定では、`deploy-web`ジョブの実行中に以下のpnpmエラーが発生し、ビルドが失敗していました。

```
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY: Aborted removal of modules directory due to no TTY

If you are running pnpm in CI, set the CI environment variable to "true".
```

このエラーは、pnpmがインタラクティブなTTY環境でないと判断した場合に発生します。
エラーメッセージの指示に従い、`CI`環境変数を`true`に設定することで、pnpmにCI環境であることを明示し、ビルドが正常に完了するようにしました。